### PR TITLE
fix: Close old meerkat for same connection id

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
+    "@babel/core": "^7.21.4",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.21.0",
     "@types/qrcode-svg": "^1.1.1",

--- a/src/DAppPeerConnect.ts
+++ b/src/DAppPeerConnect.ts
@@ -253,7 +253,10 @@ export default class DAppPeerConnect {
               connectWallet(true, true, walletInfo);
             } else {
               verifyConnection(
-                walletInfo,
+                {
+                  ...walletInfo,
+                  address: address,
+                },
                 connectWallet
               );
             }


### PR DESCRIPTION
tl;dr This fixes https://github.com/fabianbormann/cardano-peer-connect/issues/44

---

If a wallet calls connect multiple times, the list of meerkat connections clumped, even though all meerkats are for the same connection.

This commit add the option to only allow a single meerkat instance for a given identifier to exist. If a new one is created, the old one will be closed and removed.

This also fixes a small but from last commit where wallet address was not given to verify connect, which broke the autoconnect management.
