### PR TITLE
Fixed path for types. README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ import {
   CardanoPeerConnect,
   DAppPeerConnect,
 } from '@fabianbormann/cardano-peer-connect';
-import { IConnectMessage } from '@fabianbormann/cardano-peer-connect/types';
+import { IConnectMessage } from '@fabianbormann/cardano-peer-connect/dist/src/types';
 
 // the id the dapp is showing you.
 const dAppIdentifier = 'bYUh6Bn6A........388LR1JCrED';


### PR DESCRIPTION
The path for types was wrong and it can be confusing when trying to get started. I simply changed `'@fabianbormann/cardano-peer-connect/types'; to '@fabianbormann/cardano-peer-connect/dist/src/types'; so it is easy for others to get up and running as fast as possible. 